### PR TITLE
Move API to be compatible with AsyncIterable spec

### DIFF
--- a/examples/hackernews.js
+++ b/examples/hackernews.js
@@ -6,6 +6,7 @@ list()
 async function list() {
   const urls = itemize('https://news.ycombinator.com', { depth: 2 })
   while (!urls.done()) {
-    console.log(await urls.next())
+    const {value} = await urls.next()
+    console.log(value)
   }
 }

--- a/examples/nodebin.js
+++ b/examples/nodebin.js
@@ -6,6 +6,7 @@ list()
 async function list() {
   const urls = itemize('https://nodebin.herokai.com/', { depth: 3, query: true })
   while (!urls.done()) {
-    console.log(await urls.next())
+    const {value} = await urls.next();
+    console.log(value)
   }
 }

--- a/examples/nodes.js
+++ b/examples/nodes.js
@@ -7,7 +7,7 @@ list()
 // List all the node binaries on nodejs.org
 async function list() {
   while (!releases.done()) {
-    const url = await releases.next()
+    const {value: url} = await releases.next();
     if (url.match(BINARY)) console.log(`==> ${url}`)
     else console.log(`    ${url}`)
   }

--- a/examples/wikipedia.js
+++ b/examples/wikipedia.js
@@ -6,6 +6,7 @@ list()
 async function list() {
   const urls = itemize('https://en.wikipedia.org/wiki', { depth: 3 })
   while (!urls.done()) {
-    console.log(await urls.next())
+    const {value} = await urls.next()
+    console.log(value)
   }
 }

--- a/itemize.js
+++ b/itemize.js
@@ -5,6 +5,7 @@ const log = require('util').debuglog('itemize')
 const url = require('url')
 const httpAgent = require('http').Agent
 const httpsAgent = require('https').Agent
+const $$asyncIterator = require('iterall').$$asyncIterator
 
 module.exports = itemize
 
@@ -17,16 +18,26 @@ function itemize (root, opts) {
   let agent = agency(root)
   let incrementor = 0
 
-  return { next, all, done, close }
+  const module = {
+    [$$asyncIterator]: () => module,
+    next,
+    all,
+    done,
+    close
+  }
+
+  return module
 
   async function next () {
     while (queue.length > 0 && visited.length <= incrementor) {
       await scrape(queue.shift())
     }
-    if (visited.length > incrementor) return visited[incrementor++]
+    if (visited.length > incrementor) {
+      return { done: false, value: visited[incrementor++] }
+    }
     if (queue.length === 0) {
       close()
-      return undefined
+      return { done: true, value: undefined }
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "cheerio": "^0.22.0",
+    "iterall": "^1.1.1",
     "requisition": "^1.7.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,8 @@ const urls = itemize('https://news.ycombinator.com', { depth: 2 })
 
 // Get a quick Hacker News sitemap
 while (!urls.done()) {
-  console.log(await urls.next())
+  const {value} = await urls.next()
+  console.log(value)
 }
 ```
 
@@ -40,12 +41,13 @@ const items = itemize('https://nodejs.org/download/release/', { depth: 1 })
 
 ### .next()
 
-Returns a Promise for a String, the next linked URL.
+Returns [an AsyncIterator](https://github.com/tc39/proposal-async-iteration#async-iterators-and-async-iterables),
+a Promise for a `{ value, done }` pair.
 
-If no urls remain, returns a Promise for `undefined`.
+If no urls remain, it will return `{ value: undefined, done: true }`
 
 ```js
-const url = await items.next()
+const val = await items.next()
 ```
 
 ### .done()

--- a/test/itemize.test.js
+++ b/test/itemize.test.js
@@ -1,8 +1,15 @@
 const itemize = require('..')
+const iterall = require('iterall')
 const express = require('express')
+
+const {isAsyncIterable, getAsyncIterator} = iterall
 
 let server, items
 let lastHeaders
+
+function unfinishedValue(value) {
+  return { value, done: false }
+}
 
 beforeAll((done) => {
   const app = createApp()
@@ -10,9 +17,15 @@ beforeAll((done) => {
   server = app.listen(5000, done)
 })
 
+test('returns an async iterable', async () => {
+  expect(isAsyncIterable(items)).toBe(true);
+  expect(getAsyncIterator(items)).toBeDefined()
+  expect(getAsyncIterator(items)).toEqual(items)
+})
+
 test('first returns the root URL', async () => {
   const item = await items.next()
-  expect(item).toBe('http://localhost:5000/base/')
+  expect(item).toEqual(unfinishedValue('http://localhost:5000/base/'))
 })
 
 test('uses a keep-alive connection', async () => {
@@ -38,7 +51,7 @@ test('returns undefined when all items have been returned', async () => {
   let i = 10
   while(i--) {
     let item = await items.next()
-    expect(item).toBeUndefined()
+    expect(item).toEqual({ done: true, value: undefined })
   }
 })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,17 +25,13 @@ acorn-jsx@^3.0.0:
   dependencies:
     acorn "^3.0.4"
 
-acorn@4.0.4:
+acorn@4.0.4, acorn@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.4.tgz#17a8d6a7a6c4ef538b814ec9abac2779293bf30a"
 
 acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
-
-acorn@^4.0.4:
-  version "4.0.11"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.11.tgz#edcda3bd937e7556410d42ed5860f67399c794c0"
 
 ajv-keywords@^1.0.0:
   version "1.5.1"
@@ -1534,6 +1530,10 @@ istanbul-reports@^1.0.0:
   resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.0.1.tgz#9a17176bc4a6cbebdae52b2f15961d52fa623fbc"
   dependencies:
     handlebars "^4.0.3"
+
+iterall@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.1.tgz#f7f0af11e9a04ec6426260f5019d9fcca4d50214"
 
 jest-changed-files@^17.0.2:
   version "17.0.2"


### PR DESCRIPTION
This updates the API to implement the AsyncIterable interface. It's a bit of a step back in terms of usability *now*, but conforms better to where the language is going. A standard interface will work better with third party libraries and the eventual changes to the language.

Eventually we'd like to be able to do this:

```
for await (const url of itemize(...)) {
  console.log(url)
}
```

Spec: https://github.com/tc39/proposal-async-iteration
Informational blog post: http://2ality.com/2016/10/asynchronous-iteration.html

